### PR TITLE
README: add tip about submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Full list of supported keyboards can be found [here](https://github.com/rnayabed
 
 ### Compile, build and run
 
+It's important to checkout the repository with submodules. If `hidapi/` directory is empty, run this to populate it:
+
+```
+git submodule update --init --recursive
+```
+
 #### Linux / MacOS
 
 ```

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ Full list of supported keyboards can be found [here](https://github.com/rnayabed
 
 ### Compile, build and run
 
-It's important to checkout the repository with submodules. If `hidapi/` directory is empty, run this to populate it:
+Rangoli uses [hidapi](https://github.com/libusb/hidapi). It has been included as a submodule.
+Therefore, you need to clone the repository with `--recurse-submodules`.
+
+In case you forget to do that, you need to run the following command:
 
 ```
-git submodule update --init --recursive
+git submodule update --init
 ```
 
-#### Linux / MacOS
+### Linux / MacOS
 
 ```
 cmake -B build -G Ninja -S . -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Lovely project! Trying to build from source, I was getting this error:
```
CMake Error at CMakeLists.txt:54 (add_subdirectory):
  The source directory

    /home/beni/rangoli/hidapi

  does not contain a CMakeLists.txt file.
```
which was perplexing because the `hidapi/` directory was really empty but the code clearly expected things there...

Took me a while to realize it's a submodule and I didn't clone --recursive :laughing:; hopefully this README addition will save someone the trouble.