### PR TITLE
Runs with Qt 6.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,10 +53,12 @@ add_compile_definitions(
     DEFAULT_ACCENT_BLUE=115
 )
 
-find_package(Qt6 6.5 COMPONENTS Quick Svg REQUIRED) # QTBUG-55199
+find_package(Qt6 COMPONENTS Quick Svg Widgets REQUIRED)
 
 set(HIDAPI_WITH_LIBUSB FALSE)
 set(BUILD_SHARED_LIBS FALSE)
 
 add_subdirectory(hidapi)
 add_subdirectory(src)
+
+target_link_libraries(rangoli PRIVATE Qt6::Widgets)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
  * GNU General Public License for more details.
  */
 
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QLocale>
 #include <QIcon>
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
     KeyboardConfiguratorController keyboardConfiguratorController;
     SettingsController settingsController;
 
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     qInfo() << "Platform:" << app.platformName();
     qInfo() << "Qt" << qVersion();


### PR DESCRIPTION
Without this patch, rangoli won't run on a current Arch Linux system.

```
 Rangoli 2
Graphics: Hardware
Platform: "xcb"
Qt 6.7.2
Register profiles
Load settings
Apply visual settings to Main Window
Set System theme
QWidget: Cannot create a QWidget without QApplication
Aborted
```