### PR TITLE
feat: created a default keyboard loader function

### DIFF
--- a/src/mainwindowcontroller.cpp
+++ b/src/mainwindowcontroller.cpp
@@ -180,14 +180,12 @@ void MainWindowController::init()
     {
         connect(&connection, &HIDConnection::keyboardsScanComplete,
                 this, [this](){
-            QSettings settings;
 
             qInfo() << "Apply default profile";
 
             for (int i = 0 ; i < m_connectedKeyboards->keyboards().size(); i++)
             {
-                m_keyboardConfiguratorController->load(i);
-                m_keyboardConfiguratorController->applyDefaultProfile();
+                loadKeyboardWithDefaultProfile(i);
             }
         }, Qt::SingleShotConnection);
     }
@@ -278,6 +276,12 @@ void MainWindowController::refreshKeyboards()
     emit keyboardsScanningChanged();
 
     emit HIDConnection::getInstance().refreshKeyboards(m_connectedKeyboards);
+}
+
+void MainWindowController::loadKeyboardWithDefaultProfile(const int &index) {
+    m_keyboardConfiguratorController->load(index);
+
+    m_keyboardConfiguratorController->applyDefaultProfile();
 }
 
 void MainWindowController::loadKeyboard(const int &index)

--- a/src/mainwindowcontroller.h
+++ b/src/mainwindowcontroller.h
@@ -109,6 +109,7 @@ public slots:
     void init();
     void quit();
     void refreshKeyboards();
+    void loadKeyboardWithDefaultProfile(const int &index);
     void loadKeyboard(const int& index);
     void setInterruptClose(const bool& interruptClose);
     void closeInterrupted();


### PR DESCRIPTION
stay within conventions of using a dedicated `load` function for loading keyboards by adding a dedicated `loadWithDefaultProfile` function 